### PR TITLE
fix popup.js not shown

### DIFF
--- a/dev-guide.toml
+++ b/dev-guide.toml
@@ -28,17 +28,17 @@ home = [ "HTML", "RSS", "JSON"]
 
 [Languages]
 [Languages.en]
-editURL = "https://github.com/kubesphere/dev-guide/edit/master/sites/dev-guide/content/en/"
 contentDir = "sites/dev-guide/content/en"
 title = "KubeSphere Development Guide"
 weight = 1
 languageName = "English"
-landingPageURL = ""
+[Languages.en.params]
+editURL = "https://github.com/kubesphere/dev-guide/edit/master/sites/dev-guide/content/en/"
 
 [Languages.zh]
-editURL = "https://github.com/kubesphere/dev-guide/edit/master/sites/dev-guide/content/zh/"
 contentDir = "sites/dev-guide/content/zh"
 title = "KubeSphere 开发指南"
 weight = 3
 languageName = "简体中文"
-landingPageURL = ""
+[Languages.zh.params]
+editURL = "https://github.com/kubesphere/dev-guide/edit/master/sites/dev-guide/content/zh/"

--- a/extension-dev-guide.toml
+++ b/extension-dev-guide.toml
@@ -3,47 +3,47 @@ publishdir = "public/extension-dev-guide"
 languageCode = "zh-cn"
 defaultContentLanguage = "zh"
 staticDir = "static"
-title = "KubeSphere Extension Development Guide"
 theme = "hugo-theme-learn"
 themesdir = "themes"
 metaDataFormat = "yaml"
 defaultContentLanguageInSubdir = true
 # uglyURLs = true
 
+
 [markup]
-  [markup.goldmark]
-    [markup.goldmark.renderer]
-      unsafe = true
+[markup.goldmark]
+[markup.goldmark.renderer]
+unsafe = true
 
 [params]
-  description = "A set of development guidelines for KubeSphere Extension developers."
-  author = "KubeSphere"
-  showVisitedLinks = true
-  disableBreadcrumb = false
-  disableNextPrev = false
-  disableLandingPageButton = true
-  disableInlineCopyToClipBoard = true
-  disableMermaid = false
-  customMermaidURL = "https://unpkg.com/mermaid@8.8.0/dist/mermaid.min.js"
-  titleSeparator = "::"
-  themeVariant = "green"
+description = "A set of development guidelines for KubeSphere Extension developers."
+author = "KubeSphere"
+showVisitedLinks = true
+disableBreadcrumb = false
+disableNextPrev = false
+disableLandingPageButton = true
+disableInlineCopyToClipBoard = true
+disableMermaid = false
+customMermaidURL = "https://unpkg.com/mermaid@8.8.0/dist/mermaid.min.js"
+titleSeparator = "::"
+themeVariant = "green"
 
 [outputs]
-home = [ "HTML", "RSS", "JSON"]
+home = ["HTML", "RSS", "JSON"]
 
 [Languages]
 [Languages.en]
-editURL = "https://github.com/kubesphere/dev-guide/edit/master/sites/extension-dev-guide/content/en/"
 contentDir = "sites/extension-dev-guide/content/en"
 title = "KubeSphere Extension Development Guide"
 weight = 1
 languageName = "English"
-landingPageURL = ""
+[Languages.en.params]
+editURL = "https://github.com/kubesphere/dev-guide/edit/master/sites/extension-dev-guide/content/en/"
 
 [Languages.zh]
-editURL = "https://github.com/kubesphere/dev-guide/edit/master/sites/extension-dev-guide/content/zh/"
 contentDir = "sites/extension-dev-guide/content/zh"
 title = "KubeSphere 扩展组件开发指南"
 weight = 3
 languageName = "简体中文"
-landingPageURL = ""
+[Languages.zh.params]
+editURL = "https://github.com/kubesphere/dev-guide/edit/master/sites/extension-dev-guide/content/zh/"

--- a/themes/hugo-theme-learn/layouts/partials/footer.html
+++ b/themes/hugo-theme-learn/layouts/partials/footer.html
@@ -66,9 +66,9 @@
     <script src="{{"js/modernizr.custom-3.6.0.js" | relURL}}{{ if not .Site.Params.disableAssetsBusting }}?{{ now.Unix }}{{ end }}"></script>
     <script src="{{"js/learn.js" | relURL}}{{ if not .Site.Params.disableAssetsBusting }}?{{ now.Unix }}{{ end }}"></script>
     <script src="{{"js/hugo-learn.js" | relURL}}{{ if not .Site.Params.disableAssetsBusting }}?{{ now.Unix }}{{ end }}"></script>
-    {{ if in .Site.Params.contentDir "extension-dev-guide"}}
+    {{ if eq .Site.Params.Description "A set of development guidelines for KubeSphere Extension developers." }}
     <script src="{{"js/popup.js"| relURL}}{{  if not .Site.Params.disableAssetsBusting }}?{{ now.Unix }}{{ end }}"></script>
-    {{end}}
+    {{ end }}
     {{ if (or (and (ne .Params.disableMermaid nil) (not .Params.disableMermaid)) (not .Site.Params.disableMermaid)) }}
         {{ if isset .Params "custommermaidurl" }}
             <script src="{{ .Params.customMermaidURL }}"></script>


### PR DESCRIPTION
```
2:35:18 PM: WARN  config: languages.en.editurl: custom params on the language top level is deprecated and will be removed in a future release. Put the value below [languages.en.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
2:35:18 PM: WARN  config: languages.en.landingpageurl: custom params on the language top level is deprecated and will be removed in a future release. Put the value below [languages.en.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
2:35:18 PM: WARN  config: languages.zh.editurl: custom params on the language top level is deprecated and will be removed in a future release. Put the value below [languages.zh.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
2:35:18 PM: WARN  config: languages.zh.landingpageurl: custom params on the language top level is deprecated and will be removed in a future release. Put the value below [languages.zh.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
```